### PR TITLE
robot: Remove stray main file code

### DIFF
--- a/robot.py
+++ b/robot.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 import math
 import wpilib
 import wpilib.event
@@ -126,6 +125,3 @@ class MyRobot(magicbot.MagicRobot):
 
         self.vision_port.execute()
         self.vision_starboard.execute()
-
-        if __name__ == "__main__":
-            wpilib.run(MyRobot)


### PR DESCRIPTION
The indentation for the `__name__ == "__main__"` check is wrong -- it should never have been in a periodic method.

Furthermore, RobotPy's `wpilib.run()` was deprecated in 2024. Running `robot.py` as main on last season's code gives this output:

```console
$ ./robot.py sim
``wpilib.run`` is no longer used. You should run your robot code via one of
the following methods instead:

* Windows: ``py -m robotpy [arguments]``
* Linux/macOS: ``python -m robotpy [arguments]``

In a virtualenv the ``robotpy`` command can be used directly.
```

This removes all the code intended to be used for this old entry point.