### PR TITLE
Fix ids naming scheme and add docstrings

### DIFF
--- a/components/chassis.py
+++ b/components/chassis.py
@@ -32,7 +32,7 @@ from utilities.functions import rate_limit_module
 from utilities.game import is_red
 from utilities.ctre import FALCON_FREE_RPS
 from utilities.position import TeamPoses
-from ids import CancoderIds, TalonIds
+from ids import CancoderId, TalonId
 
 
 class SwerveModule:
@@ -240,33 +240,33 @@ class ChassisComponent:
             SwerveModule(
                 self.WHEEL_BASE / 2,
                 self.TRACK_WIDTH / 2,
-                TalonIds.drive_1,
-                TalonIds.steer_1,
-                CancoderIds.swerve_1,
+                TalonId.drive_1,
+                TalonId.steer_1,
+                CancoderId.swerve_1,
             ),
             # Back Left
             SwerveModule(
                 -self.WHEEL_BASE / 2,
                 self.TRACK_WIDTH / 2,
-                TalonIds.drive_2,
-                TalonIds.steer_2,
-                CancoderIds.swerve_2,
+                TalonId.drive_2,
+                TalonId.steer_2,
+                CancoderId.swerve_2,
             ),
             # Back Right
             SwerveModule(
                 -self.WHEEL_BASE / 2,
                 -self.TRACK_WIDTH / 2,
-                TalonIds.drive_3,
-                TalonIds.steer_3,
-                CancoderIds.swerve_3,
+                TalonId.drive_3,
+                TalonId.steer_3,
+                CancoderId.swerve_3,
             ),
             # Front Right
             SwerveModule(
                 self.WHEEL_BASE / 2,
                 -self.TRACK_WIDTH / 2,
-                TalonIds.drive_4,
-                TalonIds.steer_4,
-                CancoderIds.swerve_4,
+                TalonId.drive_4,
+                TalonId.steer_4,
+                CancoderId.swerve_4,
             ),
         )
 

--- a/components/chassis.py
+++ b/components/chassis.py
@@ -240,33 +240,33 @@ class ChassisComponent:
             SwerveModule(
                 self.WHEEL_BASE / 2,
                 self.TRACK_WIDTH / 2,
-                TalonId.drive_1,
-                TalonId.steer_1,
-                CancoderId.swerve_1,
+                TalonId.DRIVE_1,
+                TalonId.STEER_1,
+                CancoderId.SWERVE_1,
             ),
             # Back Left
             SwerveModule(
                 -self.WHEEL_BASE / 2,
                 self.TRACK_WIDTH / 2,
-                TalonId.drive_2,
-                TalonId.steer_2,
-                CancoderId.swerve_2,
+                TalonId.DRIVE_2,
+                TalonId.STEER_2,
+                CancoderId.SWERVE_2,
             ),
             # Back Right
             SwerveModule(
                 -self.WHEEL_BASE / 2,
                 -self.TRACK_WIDTH / 2,
-                TalonId.drive_3,
-                TalonId.steer_3,
-                CancoderId.swerve_3,
+                TalonId.DRIVE_3,
+                TalonId.STEER_3,
+                CancoderId.SWERVE_3,
             ),
             # Front Right
             SwerveModule(
                 self.WHEEL_BASE / 2,
                 -self.TRACK_WIDTH / 2,
-                TalonId.drive_4,
-                TalonId.steer_4,
-                CancoderId.swerve_4,
+                TalonId.DRIVE_4,
+                TalonId.STEER_4,
+                CancoderId.SWERVE_4,
             ),
         )
 

--- a/ids.py
+++ b/ids.py
@@ -5,27 +5,27 @@ import enum
 class TalonId(enum.IntEnum):
     """CAN ID for CTRE Talon motor controllers (e.g. Talon FX, Talon SRX)."""
 
-    drive_1 = 1
-    steer_1 = 5
+    DRIVE_1 = 1
+    STEER_1 = 5
 
-    drive_2 = 2
-    steer_2 = 6
+    DRIVE_2 = 2
+    STEER_2 = 6
 
-    drive_3 = 3
-    steer_3 = 7
+    DRIVE_3 = 3
+    STEER_3 = 7
 
-    drive_4 = 4
-    steer_4 = 8
+    DRIVE_4 = 4
+    STEER_4 = 8
 
 
 @enum.unique
 class CancoderId(enum.IntEnum):
     """CAN ID for CTRE CANcoder."""
 
-    swerve_1 = 1
-    swerve_2 = 2
-    swerve_3 = 3
-    swerve_4 = 4
+    SWERVE_1 = 1
+    SWERVE_2 = 2
+    SWERVE_3 = 3
+    SWERVE_4 = 4
 
 
 @enum.unique

--- a/ids.py
+++ b/ids.py
@@ -2,7 +2,9 @@ import enum
 
 
 @enum.unique
-class TalonIds(enum.IntEnum):
+class TalonId(enum.IntEnum):
+    """CAN ID for CTRE Talon motor controllers (e.g. Talon FX, Talon SRX)."""
+
     drive_1 = 1
     steer_1 = 5
 
@@ -17,7 +19,9 @@ class TalonIds(enum.IntEnum):
 
 
 @enum.unique
-class CancoderIds(enum.IntEnum):
+class CancoderId(enum.IntEnum):
+    """CAN ID for CTRE CANcoder."""
+
     swerve_1 = 1
     swerve_2 = 2
     swerve_3 = 3
@@ -25,15 +29,15 @@ class CancoderIds(enum.IntEnum):
 
 
 @enum.unique
-class SparkMaxIds(enum.IntEnum):
-    pass
+class SparkId(enum.IntEnum):
+    """CAN ID for REV SPARK motor controllers (Spark Max, Spark Flex)."""
 
 
 @enum.unique
-class DioChannels(enum.IntEnum):
-    pass
+class DioChannel(enum.IntEnum):
+    """roboRIO Digital I/O channel number."""
 
 
 @enum.unique
-class PwmChannels(enum.IntEnum):
-    pass
+class PwmChannel(enum.IntEnum):
+    """roboRIO PWM output channel number."""


### PR DESCRIPTION
https://docs.python.org/3/howto/enum.html recommends using `UPPER_CASE` names for enum members:

> Because Enums are used to represent constants, and to help avoid issues with name clashes between mixin-class methods/attributes and enum names, we strongly recommend using UPPER_CASE names for members, and will be using that style in our examples.

Class names should be singular. `DRIVE_1` is a "Talon ID", not a "Talon IDs". These `ids` enums were inconsistent in pluralisation with our other usages of enum last season:

- https://github.com/thedropbears/pycrescendo/blob/400c85facfc2daae178448195d53a4e92d839f04/components/led.py#L22
- https://github.com/thedropbears/pycrescendo/blob/400c85facfc2daae178448195d53a4e92d839f04/components/intake.py#L40
- https://github.com/thedropbears/pycrescendo/blob/400c85facfc2daae178448195d53a4e92d839f04/components/climber.py#L17

This also adds docstrings to each of the enums in `ids`, since our new students are likely to be unfamiliar with the intent of each enum without some clarifying context.