### PR TITLE
ruff: Enable isort

### DIFF
--- a/components/chassis.py
+++ b/components/chassis.py
@@ -1,38 +1,39 @@
-from logging import Logger
 import math
+from logging import Logger
 
-from phoenix6.hardware import TalonFX, CANcoder
-from phoenix6.controls import VoltageOut, VelocityVoltage, PositionDutyCycle
-from phoenix6.signals import InvertedValue, NeutralModeValue
-from phoenix6.configs import (
-    ClosedLoopGeneralConfigs,
-    MotorOutputConfigs,
-    FeedbackConfigs,
-    Slot0Configs,
-)
 import magicbot
 import navx
 import ntcore
 import wpilib
-from wpimath.kinematics import (
-    SwerveDrive4Kinematics,
-    ChassisSpeeds,
-    SwerveModuleState,
-    SwerveModulePosition,
-)
-from wpimath.geometry import Translation2d, Rotation2d, Pose2d
-from wpimath.estimator import SwerveDrive4PoseEstimator
-from wpimath.controller import SimpleMotorFeedforwardMeters
-from wpimath.trajectory import TrapezoidProfileRadians
-from wpimath.controller import ProfiledPIDControllerRadians
-
 from magicbot import feedback
+from phoenix6.configs import (
+    ClosedLoopGeneralConfigs,
+    FeedbackConfigs,
+    MotorOutputConfigs,
+    Slot0Configs,
+)
+from phoenix6.controls import PositionDutyCycle, VelocityVoltage, VoltageOut
+from phoenix6.hardware import CANcoder, TalonFX
+from phoenix6.signals import InvertedValue, NeutralModeValue
+from wpimath.controller import (
+    ProfiledPIDControllerRadians,
+    SimpleMotorFeedforwardMeters,
+)
+from wpimath.estimator import SwerveDrive4PoseEstimator
+from wpimath.geometry import Pose2d, Rotation2d, Translation2d
+from wpimath.kinematics import (
+    ChassisSpeeds,
+    SwerveDrive4Kinematics,
+    SwerveModulePosition,
+    SwerveModuleState,
+)
+from wpimath.trajectory import TrapezoidProfileRadians
 
+from ids import CancoderId, TalonId
+from utilities.ctre import FALCON_FREE_RPS
 from utilities.functions import rate_limit_module
 from utilities.game import is_red
-from utilities.ctre import FALCON_FREE_RPS
 from utilities.position import TeamPoses
-from ids import CancoderId, TalonId
 
 
 class SwerveModule:

--- a/components/vision.py
+++ b/components/vision.py
@@ -4,11 +4,11 @@ from typing import Optional
 
 import wpilib
 import wpiutil.log
-from magicbot import tunable, feedback
+from magicbot import feedback, tunable
 from photonlibpy import PhotonCamera
 from photonlibpy.targeting import PhotonTrackedTarget
 from wpimath import objectToRobotPose
-from wpimath.geometry import Pose2d, Rotation3d, Transform3d, Translation3d, Pose3d
+from wpimath.geometry import Pose2d, Pose3d, Rotation3d, Transform3d, Translation3d
 
 from components.chassis import ChassisComponent
 from utilities.game import apriltag_layout

--- a/physics.py
+++ b/physics.py
@@ -6,12 +6,12 @@ import typing
 import phoenix6
 import phoenix6.unmanaged
 import wpilib
+from photonlibpy.simulation import PhotonCameraSim, SimCameraProperties, VisionSystemSim
 from pyfrc.physics.core import PhysicsInterface
 from wpilib.simulation import DCMotorSim, SimDeviceSim
 from wpimath.kinematics import SwerveDrive4Kinematics
 from wpimath.system.plant import DCMotor, LinearSystemId
 from wpimath.units import kilogram_square_meters
-from photonlibpy.simulation import PhotonCameraSim, SimCameraProperties, VisionSystemSim
 
 from components.chassis import SwerveModule
 from utilities import game

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,8 @@ select = [
     "F",
     # flake8-bugbear
     "B",
+    # isort
+    "I",
     # pyupgrade
     "UP",
     # flake8-comprehensions

--- a/robot.py
+++ b/robot.py
@@ -1,14 +1,13 @@
 import math
+
+import magicbot
 import wpilib
 import wpilib.event
-from wpimath.geometry import Rotation3d, Translation3d
-import magicbot
 from magicbot import tunable
+from wpimath.geometry import Rotation3d, Translation3d
 
 from components.chassis import ChassisComponent
 from components.vision import VisualLocalizer
-
-
 from utilities.game import is_red
 from utilities.scalers import rescale_js
 

--- a/tests/test_constrain_angle.py
+++ b/tests/test_constrain_angle.py
@@ -1,4 +1,5 @@
 import math
+
 import pytest
 from hypothesis import given
 from hypothesis.strategies import floats

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,10 +1,10 @@
-from math import sin, cos, hypot
-from pytest import approx
+from math import cos, hypot, sin
+
 from hypothesis import given
 from hypothesis.strategies import floats, tuples
+from pytest import approx
 
 from utilities.functions import clamp_2d, rate_limit_2d
-
 
 sensible_floats = floats(allow_infinity=False, allow_nan=False, width=16)
 sensible_positive_floats = floats(

--- a/utilities/functions.py
+++ b/utilities/functions.py
@@ -1,6 +1,7 @@
 import math
-from wpimath.kinematics import SwerveModuleState
+
 from wpimath.geometry import Rotation2d
+from wpimath.kinematics import SwerveModuleState
 
 
 def constrain_angle(angle: float) -> float:

--- a/utilities/position.py
+++ b/utilities/position.py
@@ -1,5 +1,7 @@
 import math
-from wpimath.geometry import Pose2d, Translation2d, Rotation2d
+
+from wpimath.geometry import Pose2d, Rotation2d, Translation2d
+
 from utilities.game import field_flip_pose2d
 
 


### PR DESCRIPTION
This is intended to reduce the probability of merge conflicts (by making it more likely any changes to imports are identical), and prevent any further discussion about import ordering.