### PR TITLE
rename swerve motor and cancoder ids

### DIFF
--- a/components/chassis.py
+++ b/components/chassis.py
@@ -240,33 +240,33 @@ class ChassisComponent:
             SwerveModule(
                 self.WHEEL_BASE / 2,
                 self.TRACK_WIDTH / 2,
-                TalonId.DRIVE_1,
-                TalonId.STEER_1,
-                CancoderId.SWERVE_1,
+                TalonId.DRIVE_FL,
+                TalonId.STEER_FL,
+                CancoderId.SWERVE_FL,
             ),
             # Back Left
             SwerveModule(
                 -self.WHEEL_BASE / 2,
                 self.TRACK_WIDTH / 2,
-                TalonId.DRIVE_2,
-                TalonId.STEER_2,
-                CancoderId.SWERVE_2,
+                TalonId.DRIVE_RL,
+                TalonId.STEER_RL,
+                CancoderId.SWERVE_RL,
             ),
             # Back Right
             SwerveModule(
                 -self.WHEEL_BASE / 2,
                 -self.TRACK_WIDTH / 2,
-                TalonId.DRIVE_3,
-                TalonId.STEER_3,
-                CancoderId.SWERVE_3,
+                TalonId.DRIVE_RR,
+                TalonId.STEER_RR,
+                CancoderId.SWERVE_RR,
             ),
             # Front Right
             SwerveModule(
                 self.WHEEL_BASE / 2,
                 -self.TRACK_WIDTH / 2,
-                TalonId.DRIVE_4,
-                TalonId.STEER_4,
-                CancoderId.SWERVE_4,
+                TalonId.DRIVE_FR,
+                TalonId.STEER_FR,
+                CancoderId.SWERVE_FR,
             ),
         )
 

--- a/components/chassis.py
+++ b/components/chassis.py
@@ -244,7 +244,7 @@ class ChassisComponent:
                 TalonId.STEER_FL,
                 CancoderId.SWERVE_FL,
             ),
-            # Back Left
+            # Rear Left
             SwerveModule(
                 -self.WHEEL_BASE / 2,
                 self.TRACK_WIDTH / 2,
@@ -252,7 +252,7 @@ class ChassisComponent:
                 TalonId.STEER_RL,
                 CancoderId.SWERVE_RL,
             ),
-            # Back Right
+            # Rear Right
             SwerveModule(
                 -self.WHEEL_BASE / 2,
                 -self.TRACK_WIDTH / 2,

--- a/ids.py
+++ b/ids.py
@@ -5,27 +5,27 @@ import enum
 class TalonId(enum.IntEnum):
     """CAN ID for CTRE Talon motor controllers (e.g. Talon FX, Talon SRX)."""
 
-    DRIVE_1 = 1
-    STEER_1 = 5
+    DRIVE_FL = 1
+    STEER_FL = 5
 
-    DRIVE_2 = 2
-    STEER_2 = 6
+    DRIVE_RL = 2
+    STEER_RL = 6
 
-    DRIVE_3 = 3
-    STEER_3 = 7
+    DRIVE_RR = 3
+    STEER_RR = 7
 
-    DRIVE_4 = 4
-    STEER_4 = 8
+    DRIVE_FR = 4
+    STEER_FR = 8
 
 
 @enum.unique
 class CancoderId(enum.IntEnum):
     """CAN ID for CTRE CANcoder."""
 
-    SWERVE_1 = 1
-    SWERVE_2 = 2
-    SWERVE_3 = 3
-    SWERVE_4 = 4
+    SWERVE_FL = 1
+    SWERVE_RL = 2
+    SWERVE_RR = 3
+    SWERVE_FR = 4
 
 
 @enum.unique


### PR DESCRIPTION
Rename swerve motor and cancoder ids, replacing numbers 1-4 with FL (Front Left), RL (Rear Left), RR (Rear Right) and FR (Front Right)