### PR TITLE
Add pyright/pylance config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,15 @@ strict_equality = true
 module = "choreo.*"
 ignore_missing_imports = true
 
+[tool.pyright]
+exclude = [
+    "ctre_sim",
+    "logs",
+    # Default excludes
+    "**/__pycache__",
+    "**/.*",
+]
+
 [tool.pytest.ini_options]
 addopts = "--strict-markers -v --maxfail=2"
 pythonpath = "."


### PR DESCRIPTION
Having any pyright config will automatically enable pylance's type checking in VSCode: https://microsoft.github.io/pyright/#/configuration?id=overriding-settings-in-vs-code