### PR TITLE
vision: Assume encoder frequency for reliability

### DIFF
--- a/components/vision.py
+++ b/components/vision.py
@@ -65,6 +65,7 @@ class VisualLocalizer:
     ) -> None:
         self.camera = PhotonCamera(name)
         self.encoder = wpilib.DutyCycleEncoder(encoder_id, math.tau, 0)
+        self.encoder.setAssumedFrequency(975.6)
         # Offset of encoder in radians when facing forwards (the desired zero)
         # To find this value, manually point the camera forwards and record the encoder value
         # This has nothing to do with the servo - do it by hand!!

--- a/components/vision.py
+++ b/components/vision.py
@@ -66,6 +66,7 @@ class VisualLocalizer:
         self.camera = PhotonCamera(name)
         self.encoder = wpilib.DutyCycleEncoder(encoder_id, math.tau, 0)
         self.encoder.setAssumedFrequency(975.6)
+        self.encoder.setDutyCycleRange(1 / 1025, 1024 / 1025)
         # Offset of encoder in radians when facing forwards (the desired zero)
         # To find this value, manually point the camera forwards and record the encoder value
         # This has nothing to do with the servo - do it by hand!!


### PR DESCRIPTION
Avoid the roboRIO FPGA calculating the PWM frequency on the fly. https://robotpy.readthedocs.io/projects/robotpy/en/stable/wpilib/DutyCycleEncoder.html#wpilib.DutyCycleEncoder.setAssumedFrequency

Datasheet: https://docs.revrobotics.com/rev-crossover-products/sensors/tbe/specs#absolute-pulse-output-duty-cycle

Tested on:

- [x] this year's robot
- [x] last year's chassis