### PR TITLE
Specify minimum pre-commit version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,8 @@
 ci:
   autofix_prs: false
 
+minimum_pre_commit_version: '3.2.0'
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0


### PR DESCRIPTION
Older pre-commit versions freak out over the hooks manifest for `pre-commit-hooks`. This specifies that minimum version in our pre-commit config, so pre-commit bails out earlier with a more understandable error message than "invalid manifest".