### PR TITLE
Add per-loop cache to vision

### DIFF
--- a/components/vision.py
+++ b/components/vision.py
@@ -21,6 +21,7 @@ from wpimath.geometry import (
 )
 
 from components.chassis import ChassisComponent
+from utilities.caching import cache_per_loop
 from utilities.game import APRILTAGS, apriltag_layout
 from utilities.scalers import scale_value
 
@@ -109,6 +110,7 @@ class VisualLocalizer:
         self.chassis = chassis
         self.current_reproj = 0.0
         self.has_multitag = False
+        self._per_loop_cache: dict = {}
 
     @feedback
     def reproj(self) -> float:
@@ -123,7 +125,7 @@ class VisualLocalizer:
         # The encoder has been set up to return values in the interval [0, 2pi]
         return Rotation2d(self.encoder.get())
 
-    @feedback
+    @cache_per_loop
     def relative_bearing_to_best_cluster(self) -> Rotation2d:
         tags = self.visible_tags()
         if len(tags) == 0:
@@ -140,6 +142,7 @@ class VisualLocalizer:
         return tags[0].relative_bearing
 
     @feedback
+    @cache_per_loop
     def visible_tags(self) -> list[VisibleTag]:
         tags_in_view = []
 

--- a/components/vision.py
+++ b/components/vision.py
@@ -21,7 +21,7 @@ from wpimath.geometry import (
 )
 
 from components.chassis import ChassisComponent
-from utilities.caching import cache_per_loop
+from utilities.caching import HasPerLoopCache, cache_per_loop
 from utilities.game import APRILTAGS, apriltag_layout
 from utilities.scalers import scale_value
 
@@ -36,7 +36,7 @@ class VisibleTag:
     range: float
 
 
-class VisualLocalizer:
+class VisualLocalizer(HasPerLoopCache):
     """
     This localizes the robot from AprilTags on the field,
     using information from a single PhotonVision camera.
@@ -81,6 +81,7 @@ class VisualLocalizer:
         data_log: wpiutil.log.DataLog,
         chassis: ChassisComponent,
     ) -> None:
+        super().__init__()
         self.camera = PhotonCamera(name)
         self.encoder = wpilib.DutyCycleEncoder(encoder_id, math.tau, 0)
         self.encoder.setAssumedFrequency(975.6)
@@ -110,7 +111,6 @@ class VisualLocalizer:
         self.chassis = chassis
         self.current_reproj = 0.0
         self.has_multitag = False
-        self._per_loop_cache: dict = {}
 
     @feedback
     def reproj(self) -> float:

--- a/robot.py
+++ b/robot.py
@@ -278,3 +278,7 @@ class MyRobot(magicbot.MagicRobot):
 
         if self.gamepad.getAButtonPressed():
             self.chassis.toggle_coast_in_neutral()
+
+    def robotPeriodic(self) -> None:
+        # Clear component per-loop caches.
+        self.vision._per_loop_cache.clear()

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -2,9 +2,9 @@ from utilities import caching
 
 
 def test_cache_per_loop():
-    class Test:
+    class Test(caching.HasPerLoopCache):
         def __init__(self):
-            self._per_loop_cache = {}
+            super().__init__()
             self._bare_called = 0
             self._property_called = 0
 

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -1,0 +1,34 @@
+from utilities import caching
+
+
+def test_cache_per_loop():
+    class Test:
+        def __init__(self):
+            self._per_loop_cache = {}
+            self._bare_called = 0
+            self._property_called = 0
+
+        @caching.cache_per_loop
+        def get_bare(self):
+            self._bare_called += 1
+            return self._bare_called
+
+        @property
+        @caching.cache_per_loop
+        def a_property(self):
+            self._property_called += 1
+            return self._property_called
+
+    test = Test()
+    assert test.get_bare() == 1
+    assert test.get_bare() == 1
+    assert test.a_property == 1
+    assert test.a_property == 1
+
+    assert len(test._per_loop_cache) == 2
+    test._per_loop_cache.clear()
+
+    assert test.get_bare() == 2
+    assert test.get_bare() == 2
+    assert test.a_property == 2
+    assert test.a_property == 2

--- a/utilities/caching.py
+++ b/utilities/caching.py
@@ -1,10 +1,12 @@
 import functools
 from collections.abc import Callable
-from typing import Any, Protocol, TypeVar
+from typing import Any, TypeVar
 
 
-class HasPerLoopCache(Protocol):
-    _per_loop_cache: dict[Callable, Any]
+class HasPerLoopCache:
+    def __init__(self) -> None:
+        super().__init__()
+        self._per_loop_cache: dict[Callable, Any] = {}
 
 
 S = TypeVar("S", bound=HasPerLoopCache)

--- a/utilities/caching.py
+++ b/utilities/caching.py
@@ -1,0 +1,28 @@
+import functools
+from collections.abc import Callable
+from typing import Any, Protocol, TypeVar
+
+
+class HasPerLoopCache(Protocol):
+    _per_loop_cache: dict[Callable, Any]
+
+
+S = TypeVar("S", bound=HasPerLoopCache)
+T = TypeVar("T")
+
+
+def cache_per_loop(method: Callable[[S], T]) -> Callable[[S], T]:
+    """
+    Cache a getter method on a component until the cache is cleared.
+
+    Stores a cache in a dict called ``_per_loop_cache`` on the instance.
+    This is expected to be cleared in ``robotPeriodic()``.
+    """
+
+    @functools.wraps(method)
+    def wrapper(self: S) -> T:
+        if method not in self._per_loop_cache:
+            self._per_loop_cache[method] = method(self)
+        return self._per_loop_cache[method]
+
+    return wrapper


### PR DESCRIPTION
### Problem
We have some expensive duplicate work on each control loop in the vision component. This surfaces itself as watchdog warnings on the robot, mainly blaming our `@feedback` methods.

### Solution
Add a way to cache a getter method that is cleared at the end of every control loop iteration, and use it in the vision component.