### PR TITLE
Use Translation2d.distance method

### DIFF
--- a/autonomous/coral_auto_base.py
+++ b/autonomous/coral_auto_base.py
@@ -70,7 +70,7 @@ class CoralAutoBase(AutonomousStateMachine):
             self.next_state("scoring_coral")
             return
 
-        distance = (current_pose.translation() - final_pose.translation()).norm()
+        distance = current_pose.translation().distance(final_pose.translation())
 
         if distance < self.DISTANCE_TOLERANCE:
             self.next_state("scoring_coral")

--- a/components/ballistics.py
+++ b/components/ballistics.py
@@ -53,20 +53,17 @@ class BallisticsComponent:
     @feedback
     def range(self) -> float:
         robot_pose = self.chassis.get_pose()
+        robot_pos = robot_pose.translation()
         if is_red():
-            if robot_pose.translation().Y() > FIELD_WIDTH / 2:
-                return abs(
-                    self.barge_red_mid_end_point.X() - robot_pose.translation().X()
-                )
+            if robot_pos.Y() > FIELD_WIDTH / 2:
+                return abs(self.barge_red_mid_end_point.X() - robot_pos.X())
             else:
-                return (robot_pose.translation() - self.barge_red_mid_end_point).norm()
+                return robot_pos.distance(self.barge_red_mid_end_point)
         else:
-            if robot_pose.translation().Y() < FIELD_WIDTH / 2:
-                return abs(
-                    self.barge_blue_mid_end_point.X() - robot_pose.translation().X()
-                )
+            if robot_pos.Y() < FIELD_WIDTH / 2:
+                return abs(self.barge_blue_mid_end_point.X() - robot_pos.X())
             else:
-                return (robot_pose.translation() - self.barge_blue_mid_end_point).norm()
+                return robot_pos.distance(self.barge_blue_mid_end_point)
 
     @feedback
     def corrected_range(self) -> float:

--- a/controllers/reef_intake.py
+++ b/controllers/reef_intake.py
@@ -37,13 +37,14 @@ class ReefIntake(StateMachine):
     def intaking(self, initial_call: bool):
         if initial_call:
             current_pose = self.chassis.get_pose()
+            current_pos = current_pose.translation()
 
-            red_distance = game.RED_REEF_POS - current_pose.translation()
-            blue_distance = game.BLUE_REEF_POS - current_pose.translation()
+            red_distance = game.RED_REEF_POS.distance(current_pos)
+            blue_distance = game.BLUE_REEF_POS.distance(current_pos)
 
             if (
-                red_distance.norm() < self.ENGAGE_DISTANCE
-                or blue_distance.norm() < self.ENGAGE_DISTANCE
+                red_distance < self.ENGAGE_DISTANCE
+                or blue_distance < self.ENGAGE_DISTANCE
             ):
                 self.status_lights.too_close_to_reef()
                 self.done()
@@ -71,9 +72,11 @@ class ReefIntake(StateMachine):
 
         robot_pose = self.chassis.get_pose()
 
-        distance = self.origin_robot_pose.translation() - robot_pose.translation()
+        distance = self.origin_robot_pose.translation().distance(
+            robot_pose.translation()
+        )
 
-        if distance.norm() >= self.RETREAT_DISTANCE:
+        if distance >= self.RETREAT_DISTANCE:
             self.next_state("feeling")
 
     @state(must_finish=True)

--- a/utilities/game.py
+++ b/utilities/game.py
@@ -75,6 +75,7 @@ def is_red() -> bool:
 
 
 def nearest_reef_tag(pose: Pose2d) -> int:
+    position = pose.translation()
     distance = math.inf
     closest_tag_id = 0
 
@@ -83,9 +84,9 @@ def nearest_reef_tag(pose: Pose2d) -> int:
 
         assert tag_pose
 
-        robot_to_tag = tag_pose.toPose2d() - pose
-        if robot_to_tag.translation().norm() < distance:
-            distance = robot_to_tag.translation().norm()
+        tag_distance = tag_pose.toPose2d().translation().distance(position)
+        if tag_distance < distance:
+            distance = tag_distance
             closest_tag_id = tag_id
 
     return closest_tag_id


### PR DESCRIPTION
We have a bunch of places where we take the difference of two `Translation2d`s to then immediately take its norm and throw away the `Translation2d`. We can instead use the [`distance` method](https://robotpy.readthedocs.io/projects/robotpy/en/stable/wpimath.geometry/Translation2d.html#wpimath.geometry.Translation2d.distance) to avoid creating the intermediate `Translation2d`, and this is more descriptive.