### PR TITLE
Only reset trapezoidal profile if setpoint changes

### DIFF
--- a/components/wrist.py
+++ b/components/wrist.py
@@ -108,7 +108,9 @@ class WristComponent:
 
     def tilt_to(self, pos: float) -> None:
         clamped_angle = clamp(pos, self.MAXIMUM_DEPRESSION, self.MAXIMUM_ELEVATION)
-        if clamped_angle != self.desired_angle:
+
+        # If the new setpoint is within the tolerance we wouldn't move anyway
+        if abs(clamped_angle - self.desired_angle) > self.TOLERANCE:
             self.desired_angle = clamped_angle
             self.last_setpoint_update_time = time.monotonic()
 

--- a/components/wrist.py
+++ b/components/wrist.py
@@ -107,8 +107,10 @@ class WristComponent:
         return abs(self.desired_angle - self.inclination()) < WristComponent.TOLERANCE
 
     def tilt_to(self, pos: float) -> None:
-        self.desired_angle = clamp(pos, self.MAXIMUM_DEPRESSION, self.MAXIMUM_ELEVATION)
-        self.last_setpoint_update_time = time.monotonic()
+        clamped_angle = clamp(pos, self.MAXIMUM_DEPRESSION, self.MAXIMUM_ELEVATION)
+        if clamped_angle != self.desired_angle:
+            self.desired_angle = clamped_angle
+            self.last_setpoint_update_time = time.monotonic()
 
     def go_to_neutral(self) -> None:
         self.tilt_to(WristComponent.NEUTRAL_ANGLE)


### PR DESCRIPTION
This means multiple calls to go to a particular position will not reset the profile. This bug has caught us a lot in the past, and this will solve it forever more!