### PR TITLE
retune chassis peformance in all modes

### DIFF
--- a/components/chassis.py
+++ b/components/chassis.py
@@ -188,7 +188,7 @@ class SwerveModule:
         self.steer.set_control(self.steer_request)
 
         # rescale the speed target based on how close we are to being correctly aligned
-        target_speed = self.state.speed * target_displacement.cos() ** 2
+        target_speed = self.state.speed * target_displacement.cos()
         speed_volt = self.drive_ff.calculate(target_speed)
 
         # original position change/100ms, new m/s -> rot/s

--- a/components/chassis.py
+++ b/components/chassis.py
@@ -244,7 +244,7 @@ class ChassisComponent:
     logger: Logger
 
     send_modules = magicbot.tunable(False)
-    fudge_factor = magicbot.tunable(5)
+    fudge_factor = magicbot.tunable(12)
     do_smooth = magicbot.tunable(True)
     swerve_lock = magicbot.tunable(False)
 

--- a/components/chassis.py
+++ b/components/chassis.py
@@ -421,6 +421,9 @@ class ChassisComponent:
         else:
             desired_speeds = self.chassis_speeds
 
+        desired_speeds = ChassisSpeeds.discretize(
+            desired_speeds, self.control_loop_wait_time
+        )
         if self.swerve_lock:
             self.do_smooth = False
 

--- a/components/chassis.py
+++ b/components/chassis.py
@@ -244,7 +244,7 @@ class ChassisComponent:
     logger: Logger
 
     send_modules = magicbot.tunable(False)
-    do_fudge = magicbot.tunable(True)
+    fudge_factor = magicbot.tunable(5)
     do_smooth = magicbot.tunable(True)
     swerve_lock = magicbot.tunable(False)
 
@@ -406,20 +406,20 @@ class ChassisComponent:
                 self.get_rotation().radians(), self.get_rotational_velocity()
             )
 
-        if self.do_fudge:
-            # in the sim i found using 5 instead of 0.5 did a lot better
-            desired_speed_translation = Translation2d(
-                self.chassis_speeds.vx, self.chassis_speeds.vy
-            ).rotateBy(
-                Rotation2d(-self.chassis_speeds.omega * 5 * self.control_loop_wait_time)
+        desired_speed_translation = Translation2d(
+            self.chassis_speeds.vx, self.chassis_speeds.vy
+        ).rotateBy(
+            Rotation2d(
+                -self.chassis_speeds.omega
+                * self.fudge_factor
+                * self.control_loop_wait_time
             )
-            desired_speeds = ChassisSpeeds(
-                desired_speed_translation.x,
-                desired_speed_translation.y,
-                self.chassis_speeds.omega,
-            )
-        else:
-            desired_speeds = self.chassis_speeds
+        )
+        desired_speeds = ChassisSpeeds(
+            desired_speed_translation.x,
+            desired_speed_translation.y,
+            self.chassis_speeds.omega,
+        )
 
         desired_speeds = ChassisSpeeds.discretize(
             desired_speeds, self.control_loop_wait_time

--- a/robot.py
+++ b/robot.py
@@ -151,10 +151,10 @@ class MyRobot(magicbot.MagicRobot):
             max_spin_rate = self.max_spin_rate
 
         # Driving
-        drive_x = -rescale_js(self.gamepad.getLeftY(), 0.05, 2.5) * max_speed
-        drive_y = -rescale_js(self.gamepad.getLeftX(), 0.05, 2.5) * max_speed
+        drive_x = -rescale_js(self.gamepad.getLeftY(), 0.05, 15) * max_speed
+        drive_y = -rescale_js(self.gamepad.getLeftX(), 0.05, 15) * max_speed
         drive_z = (
-            -rescale_js(self.gamepad.getRightX(), 0.1, exponential=2) * max_spin_rate
+            -rescale_js(self.gamepad.getRightX(), 0.1, exponential=20) * max_spin_rate
         )
         local_driving = self.gamepad.getXButton()
 

--- a/robot.py
+++ b/robot.py
@@ -113,12 +113,12 @@ class MyRobot(magicbot.MagicRobot):
             self.chassis_swerve_config = SwerveConfig(
                 drive_ratio=(14.0 / 50.0) * (27.0 / 17.0) * (15.0 / 45.0),
                 drive_gains=Slot0Configs()
-                .with_k_p(0.15039)
+                .with_k_p(7.8294)
                 .with_k_i(0)
                 .with_k_d(0)
-                .with_k_s(0.21723)
-                .with_k_v(2.8697)
-                .with_k_a(0.048638),
+                .with_k_s(0.11742)
+                .with_k_v(2.3941)
+                .with_k_a(0.11426),
                 steer_ratio=(14 / 50) * (10 / 60),
                 steer_gains=Slot0Configs()
                 .with_k_p(92.079)

--- a/utilities/scalers.py
+++ b/utilities/scalers.py
@@ -27,7 +27,7 @@ def rescale_js(value: float, deadzone: float, exponential: float = 1.5) -> float
         exponential: the strength of the exponential to apply
                      (i.e. how non-linear should the response be)
     """
-    return map_exponential(apply_deadzone(value, deadzone), exponential + 1)
+    return map_exponential(apply_deadzone(value, deadzone), exponential)
 
 
 def scale_value(


### PR DESCRIPTION
I am making the chassis better in all cases

- more aggressive drive tracking
- more intuitive drive controller tracking
- adjusted fudge maths for discrete control system

[drive_be_drivey.zip](https://github.com/user-attachments/files/18723069/drive_be_drivey.zip)

tuned with TalonFX ID 1
measurement delay of 4 ms
max velocity error of 0.05 m/s
max control effort of  2 V
