### PR TITLE
Climber control improvements - deploy state and state cancelling

### DIFF
--- a/controllers/climber.py
+++ b/controllers/climber.py
@@ -20,6 +20,9 @@ class ClimberStateMachine(StateMachine):
     def retract(self) -> None:
         self.engage("retracting", force=True)
 
+    def deploy(self) -> None:
+        self.engage("deploying")
+
     @state(first=True, must_finish=True)
     def deploying(self, initial_call) -> None:
         if initial_call:
@@ -46,6 +49,13 @@ class ClimberStateMachine(StateMachine):
     @state(must_finish=True)
     def retracting(self) -> None:
         self.climber.go_to_retract()
+
+    @state(must_finish=True)
+    def deploying(self) -> None:
+        if self.climber.is_deployed():
+            self.done()
+            return
+        self.climber.deploy()
 
     def done(self) -> None:
         super().done()

--- a/controllers/climber.py
+++ b/controllers/climber.py
@@ -15,13 +15,10 @@ class ClimberStateMachine(StateMachine):
         self.heading_to_cage = 0.0
 
     def deploy(self) -> None:
-        self.engage("deploying")
+        self.engage()
 
     def retract(self) -> None:
         self.engage("retracting", force=True)
-
-    def deploy(self) -> None:
-        self.engage("deploying")
 
     @state(first=True, must_finish=True)
     def deploying(self, initial_call) -> None:
@@ -49,13 +46,6 @@ class ClimberStateMachine(StateMachine):
     @state(must_finish=True)
     def retracting(self) -> None:
         self.climber.go_to_retract()
-
-    @state(must_finish=True)
-    def deploying(self) -> None:
-        if self.climber.is_deployed():
-            self.done()
-            return
-        self.climber.deploy()
 
     def done(self) -> None:
         super().done()

--- a/robot.py
+++ b/robot.py
@@ -240,6 +240,7 @@ class MyRobot(magicbot.MagicRobot):
         if self.gamepad.getBButton():
             self.reef_intake.done()
             self.floor_intake.done()
+            self.climber_state_machine.done()
 
         self.chassis.update_odometry()
 


### PR DESCRIPTION
Added deploy state, can switch between states or cancel a state. Only in test mode, teleop is still on/off control.