### PR TITLE
ci: Set timeout to 5 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       id-token: write
 
@@ -30,6 +31,7 @@ jobs:
 
   mypy:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Occasionally the tests hang — some sort of race condition causing a deadlock between simulation threads I think? Getting a failure signal only after the 6h default timeout is kinda rough.

Set the [timeout](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes) to get a faster signal (in GitHub notifications) whilst I do some deeper debugging.