### PR TITLE
change auto misalignment colour to blue

### DIFF
--- a/components/led_component.py
+++ b/components/led_component.py
@@ -84,28 +84,28 @@ class LightStrip:
                     # Rear right
                     (
                         0.0,
-                        Color.kRed
+                        Color.kBlue
                         if translation.x > tol or translation.y > tol
                         else Color.kBlack,
                     ),
                     # Front right
                     (
                         self.right_rear_front_split,
-                        Color.kRed
+                        Color.kBlue
                         if translation.x < -tol or translation.y > tol
                         else Color.kBlack,
                     ),
                     # Front left
                     (
                         self.halfway_split,
-                        Color.kRed
+                        Color.kBlue
                         if translation.x < -tol or translation.y < -tol
                         else Color.kBlack,
                     ),
                     # Rear left
                     (
                         self.left_front_rear_split,
-                        Color.kRed
+                        Color.kBlue
                         if translation.x > tol or translation.y < -tol
                         else Color.kBlack,
                     ),


### PR DESCRIPTION
Change colour of auto misalignment to blue so it is distinguishable from there being no auto mode selected