### PR TITLE
Refactor REV Through Bore Encoder duty cycle config into helper

### DIFF
--- a/components/intake.py
+++ b/components/intake.py
@@ -13,6 +13,7 @@ from wpimath.controller import ArmFeedforward, PIDController
 from wpimath.trajectory import TrapezoidProfile
 
 from ids import DioChannel, SparkId, TalonId
+from utilities.rev import configure_through_bore_encoder
 
 
 class IntakeComponent:
@@ -38,8 +39,7 @@ class IntakeComponent:
 
         self.arm_motor = SparkMax(SparkId.INTAKE_ARM, SparkMax.MotorType.kBrushless)
         self.encoder = DutyCycleEncoder(DioChannel.INTAKE_ENCODER, math.tau, 0)
-        self.encoder.setAssumedFrequency(975.6)
-        self.encoder.setDutyCycleRange(1 / 1025, 1024 / 1025)
+        configure_through_bore_encoder(self.encoder)
         self.encoder.setInverted(True)
 
         spark_config = SparkMaxConfig()

--- a/components/vision.py
+++ b/components/vision.py
@@ -23,6 +23,7 @@ from wpimath.interpolation import TimeInterpolatableRotation2dBuffer
 from components.chassis import ChassisComponent
 from utilities.caching import HasPerLoopCache, cache_per_loop
 from utilities.game import APRILTAGS, apriltag_layout
+from utilities.rev import configure_through_bore_encoder
 from utilities.scalers import scale_value
 
 
@@ -88,8 +89,7 @@ class VisualLocalizer(HasPerLoopCache):
         super().__init__()
         self.camera = PhotonCamera(name)
         self.encoder = wpilib.DutyCycleEncoder(encoder_id, math.tau, 0)
-        self.encoder.setAssumedFrequency(975.6)
-        self.encoder.setDutyCycleRange(1 / 1025, 1024 / 1025)
+        configure_through_bore_encoder(self.encoder)
         # Offset of encoder in radians when facing forwards (the desired zero)
         # To find this value, manually point the camera forwards and record the encoder value
         # This has nothing to do with the servo - do it by hand!!

--- a/utilities/rev.py
+++ b/utilities/rev.py
@@ -1,4 +1,5 @@
 import rev
+import wpilib
 
 
 def configure_spark_ephemeral(motor: rev.SparkBase, config: rev.SparkBaseConfig):
@@ -17,3 +18,20 @@ def configure_spark_reset_and_persist(
         rev.SparkBase.ResetMode.kResetSafeParameters,
         rev.SparkBase.PersistMode.kPersistParameters,
     )
+
+
+def configure_through_bore_encoder(
+    enc: wpilib.DutyCycleEncoder, freq: float = 975.6
+) -> None:
+    """Configure a REV Through Bore Encoder absolute pulse output.
+
+    This avoids the roboRIO duty cycle frequency computation, which will
+    be inaccurate at startup.
+
+    Args:
+        enc: The DutyCycleEncoder to configure.
+        freq: The assumed frequency of the encoder in Hz. Defaults to
+            the encoder's nominal frequency per the datasheet.
+    """
+    enc.setAssumedFrequency(freq)
+    enc.setDutyCycleRange(1 / 1025, 1024 / 1025)


### PR DESCRIPTION
We have three Through Bore Encoders (using the absolute pulse output) on the robot now (one of which is being added in #229). Move the duty cycle configuration into a utility function so it's obvious why we set them.