### PR TITLE
controllers: Reference state objects in next_state calls

### DIFF
--- a/controllers/algae_measurement.py
+++ b/controllers/algae_measurement.py
@@ -27,12 +27,12 @@ class AlgaeMeasurement(StateMachine):
         self.measured_sizes = []
         self.measured_raw_sizes = []
         if all(abs(v) <= 0.0001 for v in self.shooter_component.flywheel_speeds()):
-            self.next_state("calculating")
+            self.next_state(self.calculating)
 
     @state(must_finish=True)
     def pre_measure(self, initial_call, state_tm) -> None:
         if self.retract(initial_call, state_tm):
-            self.next_state("measuring")
+            self.next_state(self.measuring)
 
     @state(must_finish=True)
     def calculating(self) -> None:
@@ -41,9 +41,9 @@ class AlgaeMeasurement(StateMachine):
             self.shooter_component.algae_size = sum(self.measured_sizes[1:]) / (
                 len(self.measured_sizes) - 1
             )
-            self.next_state("recovering")
+            self.next_state(self.recovering)
         else:
-            self.next_state("pre_measure")
+            self.next_state(self.pre_measure)
 
     @state(must_finish=True)
     def measuring(self, initial_call) -> None:
@@ -76,7 +76,7 @@ class AlgaeMeasurement(StateMachine):
                 scale_value(injector_position_delta, 7.2, 4.9, 16.0, 17.0)
             )
 
-            self.next_state("calculating")
+            self.next_state(self.calculating)
 
     @state(must_finish=True)
     def recovering(self, initial_call, state_tm) -> None:

--- a/controllers/algae_shooter.py
+++ b/controllers/algae_shooter.py
@@ -57,7 +57,7 @@ class AlgaeShooter(StateMachine):
             and self.shooter_component.top_flywheels_up_to_speed()
             and self.shooter_component.bottom_flywheels_up_to_speed()
         ):
-            self.next_state("shooting")
+            self.next_state(self.shooting)
 
     @timed_state(duration=1, must_finish=True)
     def shooting(self) -> None:

--- a/controllers/coral_placer.py
+++ b/controllers/coral_placer.py
@@ -40,7 +40,7 @@ class CoralPlacer(StateMachine):
             self.wrist.tilt_to(math.radians(self.CORAL_LOWER_ANGLE))
         if self.wrist.at_setpoint():
             self.coral_scored = True
-            self.next_state("safing")
+            self.next_state(self.safing)
 
     @state(must_finish=True)
     def safing(self, initial_call: bool) -> None:

--- a/controllers/feeler.py
+++ b/controllers/feeler.py
@@ -29,7 +29,7 @@ class Feeler(StateMachine):
         self.feeler_component.set_angle(self.feeler_component.current_angle)
 
         if self.feeler_component.touching_algae():
-            self.next_state("found")
+            self.next_state(self.found)
             return
 
         self.feeler_component.current_angle += self.DETECT_SPEED

--- a/controllers/floor_intake.py
+++ b/controllers/floor_intake.py
@@ -32,7 +32,7 @@ class FloorIntake(StateMachine):
             return
 
         if self.injector_component.has_algae():
-            self.next_state("measuring")
+            self.next_state(self.measuring)
             return
 
         self.intake_component.intake()

--- a/controllers/reef_intake.py
+++ b/controllers/reef_intake.py
@@ -59,7 +59,7 @@ class ReefIntake(StateMachine):
                 return
 
         if self.injector_component.has_algae():
-            self.next_state("safing")
+            self.next_state(self.safing)
             return
 
         nearest_tag_pose = (game.nearest_reef_tag(current_pose))[1]


### PR DESCRIPTION
### Problem

I've seen multiple folks trip up by either typoing a state name, or missing a reference when removing a state.

### Solution

Use the `.next_state()` syntax which allows for the type checker in the IDE to catch such mistakes early.