### PR TITLE
chassis: Stop motors on disable

### DIFF
--- a/components/chassis.py
+++ b/components/chassis.py
@@ -447,6 +447,7 @@ class ChassisComponent:
     def on_disable(self) -> None:
         for module in self.modules:
             module.stop()
+        self.stop_snapping()
         self.set_coast_in_neutral(coast_mode=False)
 
     def get_rotational_velocity(self) -> float:

--- a/components/chassis.py
+++ b/components/chassis.py
@@ -175,10 +175,7 @@ class SwerveModule:
         self.state.optimize(current_angle)
 
         if abs(self.state.speed) < 0.01 and not self.module_locked:
-            self.drive.set_control(
-                self.drive_request.with_velocity(0).with_feed_forward(0)
-            )
-            self.steer.set_control(self.stop_request)
+            self.stop()
             return
 
         target_displacement = self.state.angle - current_angle
@@ -194,6 +191,10 @@ class SwerveModule:
         self.drive.set_control(
             self.drive_request.with_velocity(target_speed).with_feed_forward(speed_volt)
         )
+
+    def stop(self):
+        self.drive.set_control(self.drive_request.with_velocity(0).with_feed_forward(0))
+        self.steer.set_control(self.stop_request)
 
     def sync_steer_encoder(self) -> None:
         self.steer.set_position(self.get_angle_absolute())
@@ -444,6 +445,8 @@ class ChassisComponent:
         self.set_coast_in_neutral(False)
 
     def on_disable(self) -> None:
+        for module in self.modules:
+            module.stop()
         self.set_coast_in_neutral(coast_mode=False)
 
     def get_rotational_velocity(self) -> float:

--- a/components/chassis.py
+++ b/components/chassis.py
@@ -447,6 +447,8 @@ class ChassisComponent:
     def on_disable(self) -> None:
         for module in self.modules:
             module.stop()
+            # Also reset the state to account for the internal smoothing
+            module.state = SwerveModuleState(0, module.get_rotation())
         self.stop_snapping()
         self.set_coast_in_neutral(coast_mode=False)
 


### PR DESCRIPTION
Fixes #272

### Test plan

1. Start an auto routine
2. Disable the robot midway through a path
3. Enable the robot in teleop or test mode
4. See that the robot doesn't immediately start driving without an input