### PR TITLE
decrease intake retreat threshold

### DIFF
--- a/controllers/reef_intake.py
+++ b/controllers/reef_intake.py
@@ -23,7 +23,7 @@ class ReefIntake(StateMachine):
     L2_INTAKE_ANGLE = tunable(math.radians(-40.0))
     L3_INTAKE_ANGLE = tunable(math.radians(-5.0))
 
-    RETREAT_DISTANCE = tunable(0.6)  # metres
+    RETREAT_DISTANCE = tunable(0.3)  # metres
     ENGAGE_DISTANCE = tunable(1.5)  # metres
 
     def __init__(self):


### PR DESCRIPTION
we are safer now that we stop longitudinal velocity when safing so we can decrease that distance