### PR TITLE
Add flywheel-based auto depositing

### DIFF
--- a/autonomous/auto_base.py
+++ b/autonomous/auto_base.py
@@ -97,6 +97,9 @@ class AutoBase(AutonomousStateMachine):
         distance = current_pose.translation().distance(final_pose.translation())
         angle_error = (final_pose.rotation() - current_pose.rotation()).radians()
 
+        if self.current_leg == 0:
+            self.reef_intake.must_deposit_coral = True
+
         if self.current_leg % 2 != 0:
             self.algae_shooter.shoot()
         else:

--- a/controllers/reef_intake.py
+++ b/controllers/reef_intake.py
@@ -83,14 +83,14 @@ class ReefIntake(StateMachine):
             self.last_l3 = current_is_L3
 
         if self.must_deposit_coral:
-            self.must_deposit_coral = False
             self.next_state(self.deposit_coral_delay)
+        else:
+            self.shooter_component.intake()
+            self.injector_component.intake()
 
-        self.shooter_component.intake()
-        self.injector_component.intake()
-
-    @timed_state(duration=1, next_state="intaking")
+    @timed_state(duration=0.6, next_state="intaking")
     def deposit_coral_delay(self):
+        self.must_deposit_coral = False
         self.wrist.tilt_to(self.DEPOSIT_ANGLE)
 
     @state(must_finish=True)


### PR DESCRIPTION
Intend to briefly stop the wrist at a low angle on the first leg of auto. The wrist will move to the deposit level before flywheels start. I think the wrist will move at the same time the wrist starts to move up to intake, and I'm not sure if we can get away with this