### PR TITLE
Fix motion profile gating

### DIFF
--- a/components/intake.py
+++ b/components/intake.py
@@ -89,6 +89,8 @@ class IntakeComponent:
     def retract(self):
         if not math.isclose(
             self.desired_state.position, self.RETRACTED_ANGLE, abs_tol=0.1
+        ) or self.motion_profile.isFinished(
+            wpilib.Timer.getFPGATimestamp() - self.last_setpoint_update_time
         ):
             self.desired_state = TrapezoidProfile.State(
                 IntakeComponent.RETRACTED_ANGLE, 0.0

--- a/components/wrist.py
+++ b/components/wrist.py
@@ -137,7 +137,11 @@ class WristComponent:
         clamped_angle = clamp(pos, self.MAXIMUM_DEPRESSION, self.MAXIMUM_ELEVATION)
 
         # If the new setpoint is within the tolerance we wouldn't move anyway
-        if abs(clamped_angle - self.desired_state.position) > self.TOLERANCE:
+        if abs(
+            clamped_angle - self.desired_state.position
+        ) > self.TOLERANCE or self.wrist_profile.isFinished(
+            wpilib.Timer.getFPGATimestamp() - self.last_setpoint_update_time
+        ):
             self.desired_state = TrapezoidProfile.State(clamped_angle, 0.0)
             self.last_setpoint_update_time = wpilib.Timer.getFPGATimestamp()
             self.initial_state = TrapezoidProfile.State(


### PR DESCRIPTION
Stop a weird interaction that can happen between done in our state machines and on enable in the component.

1. done is called setting the default setpoint
2. enable is called trying to update the setpoint to the same location
3. this gets rejected because we only gate based on the position of the setpoint
4. we slam real hard because we have incorrectly rejected a setpoint update with a new start time and we try to catch up to the old one