### PR TITLE
ci: Fix codecov uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
       id-token: write
 
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           name: coverage-data


### PR DESCRIPTION
Turns out the Codecov uploader looks at the git repo, so this separate job added in #331 needs the git repo checked out too. https://docs.codecov.com/docs/error-reference#unusable-reports

This resurrects the codecov checks on PRs.