### PR TITLE
vision: Optimise VisualLocalizer.visible_tags()

### DIFF
--- a/components/vision.py
+++ b/components/vision.py
@@ -211,12 +211,14 @@ class VisualLocalizer(HasPerLoopCache):
 
         robot_pose = self.chassis.get_pose()
         turret_pose = robot_pose.transformBy(self.robot_to_turret_2d)
+        turret_translation = turret_pose.translation()
+        turret_rotation = turret_pose.rotation()
 
         for tag in APRILTAGS_2D:
             tag_pose = tag.pose
-            turret_to_tag = tag_pose.translation() - turret_pose.translation()
+            turret_to_tag = tag_pose.translation() - turret_translation
             turret_angle_to_tag = turret_to_tag.angle()
-            relative_bearing = turret_angle_to_tag - turret_pose.rotation()
+            relative_bearing = turret_angle_to_tag - turret_rotation
             distance = turret_to_tag.norm()
             relative_facing = tag_pose.rotation() - turret_angle_to_tag
             relative_bearing_rad = relative_bearing.radians()

--- a/components/vision.py
+++ b/components/vision.py
@@ -213,12 +213,12 @@ class VisualLocalizer(HasPerLoopCache):
         turret_pose = robot_pose.transformBy(self.robot_to_turret_2d)
 
         for tag in APRILTAGS:
-            turret_to_tag = (
-                tag.pose.toPose2d().translation() - turret_pose.translation()
-            )
-            relative_bearing = turret_to_tag.angle() - turret_pose.rotation()
+            tag_pose = tag.pose.toPose2d()
+            turret_to_tag = tag_pose.translation() - turret_pose.translation()
+            turret_angle_to_tag = turret_to_tag.angle()
+            relative_bearing = turret_angle_to_tag - turret_pose.rotation()
             distance = turret_to_tag.norm()
-            relative_facing = tag.pose.toPose2d().rotation() - turret_to_tag.angle()
+            relative_facing = tag_pose.rotation() - turret_angle_to_tag
             relative_bearing_rad = relative_bearing.radians()
             # Make the angle less than the max rotation, then see if we are above the min too
             in_rotation_range = False

--- a/components/vision.py
+++ b/components/vision.py
@@ -22,7 +22,7 @@ from wpimath.interpolation import TimeInterpolatableRotation2dBuffer
 from components.chassis import ChassisComponent
 from utilities.caching import HasPerLoopCache, cache_per_loop
 from utilities.functions import clamp
-from utilities.game import APRILTAGS, apriltag_layout
+from utilities.game import APRILTAGS_2D, apriltag_layout
 from utilities.rev import configure_through_bore_encoder
 
 
@@ -212,8 +212,8 @@ class VisualLocalizer(HasPerLoopCache):
         robot_pose = self.chassis.get_pose()
         turret_pose = robot_pose.transformBy(self.robot_to_turret_2d)
 
-        for tag in APRILTAGS:
-            tag_pose = tag.pose.toPose2d()
+        for tag in APRILTAGS_2D:
+            tag_pose = tag.pose
             turret_to_tag = tag_pose.translation() - turret_pose.translation()
             turret_angle_to_tag = turret_to_tag.angle()
             relative_bearing = turret_angle_to_tag - turret_pose.rotation()
@@ -241,7 +241,7 @@ class VisualLocalizer(HasPerLoopCache):
             ):
                 # Test for relative facing is more than 90 degrees because we don't want to be too
                 # close to parallel to the tag
-                tags_in_view.append(VisibleTag(tag.ID, relative_bearing_rad, distance))
+                tags_in_view.append(VisibleTag(tag.id, relative_bearing_rad, distance))
 
         return tags_in_view
 

--- a/utilities/game.py
+++ b/utilities/game.py
@@ -1,5 +1,6 @@
 """Descriptions of the field and match state."""
 
+import dataclasses
 import math
 import typing
 
@@ -26,6 +27,18 @@ get_fiducial_pose = typing.cast(
 )
 
 APRILTAGS = apriltag_layout.getTags()
+
+
+@dataclasses.dataclass(slots=True)
+class Tag2d:
+    id: TagId
+    pose: Pose2d
+
+
+APRILTAGS_2D = [
+    Tag2d(typing.cast(TagId, tag.ID), tag.pose.toPose2d()) for tag in APRILTAGS
+]
+
 
 L3_TAGS = [7, 9, 11, 18, 20, 22]
 L2_TAGS = [6, 8, 10, 17, 19, 21]


### PR DESCRIPTION
I ran the [Scalene](https://github.com/plasma-umass/scalene) profiler on our code. I noticed the two lines
```python
tag.pose.toPose2d().translation() - turret_pose.translation()
...
relative_facing = tag.pose.toPose2d().rotation() - turret_to_tag.angle()
```
were being highlighted as lines that the code was spending a non-negligible amount of time in. This is noteworthy particularly since Scalene is a sampling profiler!

Since there's easy wins here, I went in and did a little perf optimisation in here.