### PR TITLE
ci: Run Astral's ty type checker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,17 @@ jobs:
         with:
           linters: mypy
           run: uv run mypy --show-column-numbers .
+
+  ty:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.6.x"
+      - name: Install dependencies
+        run: |
+          uv sync --locked
+      - run: uvx ty check robot.py


### PR DESCRIPTION
https://github.com/astral-sh/ty

> [!NOTE]
> ty is very much still in preview. The tests currently don't type check under ty, for reasons I'm still unsure why.