### PR TITLE
Enable pytest faulthandler timeout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ exclude = [
 
 [tool.pytest.ini_options]
 addopts = "--strict-markers -v --maxfail=2"
+faulthandler_timeout = 20
 pythonpath = "."
 testpaths = ["tests"]
 xfail_strict = true


### PR DESCRIPTION
We apparently have a non-deterministically hanging test. This tells pytest to dump stacktraces when a test hangs for over 20s.

https://docs.pytest.org/en/stable/how-to/failures.html#fault-handler