### PR TITLE
Bump pytest faulthandler timeout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ exclude = [
 
 [tool.pytest.ini_options]
 addopts = "--strict-markers -v --maxfail=2"
-faulthandler_timeout = 20
+faulthandler_timeout = 40
 pythonpath = "."
 testpaths = ["tests"]
 xfail_strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ exclude = [
 
 [tool.pytest.ini_options]
 addopts = "--strict-markers -v --maxfail=2"
-faulthandler_timeout = 40
+faulthandler_timeout = 60
 pythonpath = "."
 testpaths = ["tests"]
 xfail_strict = true


### PR DESCRIPTION
I'm occasionally seeing access violations on my Windows laptop in the middle of the faulthandler after a timeout. We've also seen it segfault in CI and on Linux laptops 😅

Examples:

<details>
<summary>AV immediately after reading phoenix6 all timestamps stack frame</summary>

```
tests/autonomous_test.py::test_all_autonomous[Red] Timeout (0:00:20)!
Thread 0x000061d4 (most recent call first):
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\phoenix6\all_timestamps.py"Windows fatal exception: access violation

Thread 0x000061d4 (most recent call first):
  File "C:\Users\David\git\thedropbears\pyreefscape\components\vision.py", line 132 in raw_encoder_rotation
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\magicbot\magicrobot.py", line 726 in _do_periodics
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\magicbot\magicrobot.py", line 752 in _enabled_periodic
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\robotpy_ext\autonomous\selector.py", line 296 in run
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\magicbot\magicrobot.py", line 409 in autonomous
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\magicbot\magicrobot.py", line 376 in startCompetition
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\pyfrc\test_support\controller.py", line 42 in _robot_thread      
  File "C:\Users\David\AppData\Roaming\uv\python\cpython-3.13.3-windows-x86_64-none\Lib\threading.py", line 992 in run
  File "C:\Users\David\AppData\Roaming\uv\python\cpython-3.13.3-windows-x86_64-none\Lib\threading.py", line 1041 in _bootstrap_inner
  File "C:\Users\David\AppData\Roaming\uv\python\cpython-3.13.3-windows-x86_64-none\Lib\threading.py", line 1012 in _bootstrap

Thread 0x00006290 (most recent call first):
  <no Python frame>

Thread 0x00003260 (most recent call first):
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\ntcore\_logutil.py", line 94 in _logging_thread
  File "C:\Users\David\AppData\Roaming\uv\python\cpython-3.13.3-windows-x86_64-none\Lib\threading.py", line 992 in run
  File "C:\Users\David\AppData\Roaming\uv\python\cpython-3.13.3-windows-x86_64-none\Lib\threading.py", line 1041 in _bootstrap_inner
  File "C:\Users\David\AppData\Roaming\uv\python\cpython-3.13.3-windows-x86_64-none\Lib\threading.py", line 1012 in _bootstrap

Thread 0x00005eb0 (most recent call first):
  <no Python frame>

Thread 0x00005e1c (most recent call first):
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\photonlibpy\timesync\timeSyncServer.py", line 64 in _udp_server  
  File "C:\Users\David\AppData\Roaming\uv\python\cpython-3.13.3-windows-x86_64-none\Lib\threading.py", line 992 in run
  File "C:\Users\David\AppData\Roaming\uv\python\cpython-3.13.3-windows-x86_64-none\Lib\threading.py", line 1041 in _bootstrap_inner
  File "C:\Users\David\AppData\Roaming\uv\python\cpython-3.13.3-windows-x86_64-none\Lib\threading.py", line 1012 in _bootstrap

Thread 0x00002224 (most recent call first):
  <no Python frame>

Thread 0x00005240 (most recent call first):
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\pyfrc\test_support\controller.py", line 154 in step_timing       
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\robotpy_ext\autonomous\selector_tests.py", line 40 in test_all_autonomous
  File "C:\Users\David\git\thedropbears\pyreefscape\tests\autonomous_test.py", line 15 in test_all_autonomous
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\_pytest\python.py", line 159 in pytest_pyfunc_call
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\pluggy\_callers.py", line 103 in _multicall
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\pluggy\_manager.py", line 120 in _hookexec
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\pluggy\_hooks.py", line 513 in __call__
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\_pytest\python.py", line 1627 in runtest
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\_pytest\runner.py", line 174 in pytest_runtest_call
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\pluggy\_callers.py", line 103 in _multicall
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\pluggy\_manager.py", line 120 in _hookexec
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\pluggy\_hooks.py", line 513 in __call__
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\_pytest\runner.py", line 242 in <lambda>
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\_pytest\runner.py", line 341 in from_call
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\_pytest\runner.py", line 241 in call_and_report
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\_pytest\runner.py", line 132 in runtestprotocol
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\_pytest\runner.py", line 113 in pytest_runtest_protocol
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\pluggy\_callers.py", line 103 in _multicall
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\pluggy\_manager.py", line 120 in _hookexec
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\pluggy\_hooks.py", line 513 in __call__
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\_pytest\main.py", line 362 in pytest_runtestloop
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\pluggy\_callers.py", line 103 in _multicall
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\pluggy\_manager.py", line 120 in _hookexec
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\pluggy\_hooks.py", line 513 in __call__
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\_pytest\main.py", line 337 in _main
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\_pytest\main.py", line 283 in wrap_session
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\_pytest\main.py", line 330 in pytest_cmdline_main
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\pluggy\_callers.py", line 103 in _multicall
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\pluggy\_manager.py", line 120 in _hookexec
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\pluggy\_hooks.py", line 513 in __call__
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\_pytest\config\__init__.py", line 175 in main
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\pyfrc\mains\cli_test.py", line 173 in _run_test
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\pyfrc\mains\cli_test.py", line 101 in run
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\robotpy\main.py", line 314 in main
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\robotpy\__main__.py", line 4 in <module>
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\coverage\execfile.py", line 212 in run
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\coverage\cmdline.py", line 858 in do_run
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\coverage\cmdline.py", line 681 in command_line
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\coverage\cmdline.py", line 970 in main
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\coverage\__main__.py", line 10 in <module>
  File "<frozen runpy>", line 88 in _run_code
  File "<frozen runpy>", line 198 in _run_module_as_main
```

</details>

<details>
<summary>AV reading a stack in the middle of enum code?</summary>

```
tests/autonomous_test.py::test_all_autonomous[Blue] Timeout (0:00:20)!
Thread 0x000060f0 (most recent call first):
  File "C:\Users\David\AppData\Roaming\uv\python\cpython-3.13.3-windows-x86_64-none\Lib\enum.py"Windows fatal exception: access violation    

Thread 0x000060f0 (most recent call first):
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\magicbot\magicrobot.py", line 747 in _enabled_periodic
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\robotpy_ext\autonomous\selector.py", line 296 in run
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\magicbot\magicrobot.py", line 409 in autonomous
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\magicbot\magicrobot.py", line 376 in startCompetition
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\pyfrc\test_support\controller.py", line 42 in _robot_thread      
  File "C:\Users\David\AppData\Roaming\uv\python\cpython-3.13.3-windows-x86_64-none\Lib\threading.py", line 992 in run
  File "C:\Users\David\AppData\Roaming\uv\python\cpython-3.13.3-windows-x86_64-none\Lib\threading.py", line 1041 in _bootstrap_inner
  File "C:\Users\David\AppData\Roaming\uv\python\cpython-3.13.3-windows-x86_64-none\Lib\threading.py", line 1012 in _bootstrap

Thread 0x00003814 (most recent call first):
  <no Python frame>

Thread 0x000060e0 (most recent call first):
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\ntcore\_logutil.py", line 94 in _logging_thread
  File "C:\Users\David\AppData\Roaming\uv\python\cpython-3.13.3-windows-x86_64-none\Lib\threading.py", line 992 in run
  File "C:\Users\David\AppData\Roaming\uv\python\cpython-3.13.3-windows-x86_64-none\Lib\threading.py", line 1041 in _bootstrap_inner
  File "C:\Users\David\AppData\Roaming\uv\python\cpython-3.13.3-windows-x86_64-none\Lib\threading.py", line 1012 in _bootstrap

Thread 0x00002bf8 (most recent call first):
  <no Python frame>

Thread 0x00006230 (most recent call first):
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\photonlibpy\timesync\timeSyncServer.py", line 64 in _udp_server  
  File "C:\Users\David\AppData\Roaming\uv\python\cpython-3.13.3-windows-x86_64-none\Lib\threading.py", line 992 in run
  File "C:\Users\David\AppData\Roaming\uv\python\cpython-3.13.3-windows-x86_64-none\Lib\threading.py", line 1041 in _bootstrap_inner
  File "C:\Users\David\AppData\Roaming\uv\python\cpython-3.13.3-windows-x86_64-none\Lib\threading.py", line 1012 in _bootstrap

Thread 0x00005128 (most recent call first):
  <no Python frame>

Thread 0x00000830 (most recent call first):
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\pyfrc\test_support\controller.py", line 154 in step_timing       
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\robotpy_ext\autonomous\selector_tests.py", line 40 in test_all_autonomous
  File "C:\Users\David\git\thedropbears\pyreefscape\tests\autonomous_test.py", line 15 in test_all_autonomous
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\_pytest\python.py", line 159 in pytest_pyfunc_call
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\pluggy\_callers.py", line 103 in _multicall
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\pluggy\_manager.py", line 120 in _hookexec
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\pluggy\_hooks.py", line 513 in __call__
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\_pytest\python.py", line 1627 in runtest
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\_pytest\runner.py", line 174 in pytest_runtest_call
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\pluggy\_callers.py", line 103 in _multicall
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\pluggy\_manager.py", line 120 in _hookexec
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\pluggy\_hooks.py", line 513 in __call__
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\_pytest\runner.py", line 242 in <lambda>
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\_pytest\runner.py", line 341 in from_call
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\_pytest\runner.py", line 241 in call_and_report
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\_pytest\runner.py", line 132 in runtestprotocol
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\_pytest\runner.py", line 113 in pytest_runtest_protocol
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\pluggy\_callers.py", line 103 in _multicall
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\pluggy\_manager.py", line 120 in _hookexec
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\pluggy\_hooks.py", line 513 in __call__
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\_pytest\main.py", line 362 in pytest_runtestloop
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\pluggy\_callers.py", line 103 in _multicall
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\pluggy\_manager.py", line 120 in _hookexec
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\pluggy\_hooks.py", line 513 in __call__
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\_pytest\main.py", line 337 in _main
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\_pytest\main.py", line 283 in wrap_session
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\_pytest\main.py", line 330 in pytest_cmdline_main
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\pluggy\_callers.py", line 103 in _multicall
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\pluggy\_manager.py", line 120 in _hookexec
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\pluggy\_hooks.py", line 513 in __call__
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\_pytest\config\__init__.py", line 175 in main
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\pyfrc\mains\cli_test.py", line 173 in _run_test
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\pyfrc\mains\cli_test.py", line 101 in run
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\robotpy\main.py", line 314 in main
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\robotpy\__main__.py", line 4 in <module>
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\coverage\execfile.py", line 212 in run
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\coverage\cmdline.py", line 858 in do_run
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\coverage\cmdline.py", line 681 in command_line
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\coverage\cmdline.py", line 970 in main
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\coverage\__main__.py", line 10 in <module>
  File "<frozen runpy>", line 88 in _run_code
  File "<frozen runpy>", line 198 in _run_module_as_main
```

</details>

<details>
<summary>Double AV with faulthandler triggering faulthandler??</summary>

```
tests\autonomous_test.py Timeout (0:00:20)!
Thread 0x00005a6c (most recent call first):
  File "C:\Users\David\git\thedropbears\pyreefscape\.venv\Lib\site-packages\phoenix6\hardware\device_identifier.py", line 83 in device_id    
  File Windows fatal exception: access violation

Thread 0x00005a6c (most recent call first):
  File "C:\Users\David\AppData\Roaming\uv\python\cpython-3.13.3-windows-x86_64-none\Lib\enum.py", line 4 in value
  File Windows fatal exception: access violation
```

</details>

Since I also see the faulthandler timeout being triggered on my laptop on battery when running the tests with coverage, let's increase this timeout.